### PR TITLE
Add secret item to ItemPoolsRedRoom

### DIFF
--- a/src/main/java/com/hbm/itempool/ItemPoolsRedRoom.java
+++ b/src/main/java/com/hbm/itempool/ItemPoolsRedRoom.java
@@ -41,6 +41,7 @@ public class ItemPoolsRedRoom {
 
                     weighted(ModItems.gun_hangman, 0, 1, 1, 1),
                     weighted(ModItems.gun_mas36, 0, 1, 1, 1),
+                    weighted(ModItems.item_secret, EnumSecretType.FOLLY.ordinal(), 1, 1, 1),
             };
         }};
 


### PR DESCRIPTION
The folly part was missing from the loot pool, making the folly impossible to acquire.

the ultrakill gun mods are also missing, but the gun itself is not apart of the loot pool yet eiter