### PR TITLE
Fix dynamictrees issue #1606

### DIFF
--- a/src/main/java/com/hbm/config/GeneralConfig.java
+++ b/src/main/java/com/hbm/config/GeneralConfig.java
@@ -80,6 +80,7 @@ public class GeneralConfig {
 	public static boolean enableServerRecipeSync = true;
 	public static boolean enableMachineGravity = false;
 	public static boolean enableExpensiveMode = false;
+	public static boolean dynamicTreesCompatMode = false;
 
 	public static boolean trueExp() {
 		return enableExpensiveMode && !PrecAssRecipes.INSTANCE.modified;
@@ -243,6 +244,7 @@ public class GeneralConfig {
 		enableMachineGravity = config.get(CommonConfig.CATEGORY_GENERAL, "1.44_enableMachineGravity", false, "Requires large large machines to have a proper foundation, or else they tilt and break. Independent from the 528 version of this config, which does the same, but only works with 528 enabled.").getBoolean(false);
 		enableFluidContainersV2 = CommonConfig.createConfigBool(config, CommonConfig.CATEGORY_GENERAL, "1.99_CE_enableFluidContainersV2", "If enabled, 3 new enhanced version of base fluid barrels that supports partial fill and drain are added.", false);
 		leadSafeForgeContainerWhitelist = loadLeadSafeForgeContainerWhitelist(config);
+		dynamicTreesCompatMode = config.get(CommonConfig.CATEGORY_GENERAL, "1.67_dynamicTreesCompatMode", false, "Prevents HBM from reenabling tree, big shroom and cactus generation that was disabled by DynamicTrees").getBoolean(false);
 		enableExpensiveMode = config.get(CommonConfig.CATEGORY_GENERAL, "1.99_enableExpensiveMode", false, "It does what the name implies.").getBoolean(false);
         
 

--- a/src/main/java/com/hbm/main/ModEventHandlerImpact.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerImpact.java
@@ -219,12 +219,12 @@ public class ModEventHandlerImpact {
 
 	@SubscribeEvent
 	public void postImpactDecoration(DecorateBiomeEvent.Decorate event) {
-		
 		TomSaveData data = TomSaveData.forWorld(event.getWorld());
-		
-		if(data.impact) {
-			EventType type = event.getType();
-			
+		EventType type = event.getType();
+
+		if ((GeneralConfig.dynamicTreesCompatMode)&&(type == event.getType().TREE || type == event.getType().BIG_SHROOM || type == event.getType().CACTUS)) return;
+
+		if(data.impact) {	
 			if(data.dust > 0 || data.fire > 0) {
 				if(type == event.getType().TREE || type == event.getType().BIG_SHROOM || type == event.getType().GRASS || type == event.getType().REED || type == event.getType().FLOWERS || type == event.getType().DEAD_BUSH
 						|| type == event.getType().CACTUS || type == event.getType().PUMPKIN || type == event.getType().LILYPAD) {


### PR DESCRIPTION
Fix for #1606 . Dynamic trees prevents spawning vanilla trees by listening for DecorateBiomeEvent and setting the result for trees, big shrooms and cactus to deny, HBM event handler for this event would run after and change the result to default leading to spawning both trees. Enabling the option in config skips the HBM event handler for those events.