### PR TITLE
Ok, who the *QuACK* set this to false by default?

### DIFF
--- a/src/main/java/com/hbm/config/ClientConfig.java
+++ b/src/main/java/com/hbm/config/ClientConfig.java
@@ -36,7 +36,7 @@ public class ClientConfig extends RunningConfig {
     public static ConfigWrapper<Integer> TOOL_HUD_INDICATOR_Y = 			new ConfigWrapper<>(0);
     public static ConfigWrapper<Boolean> SHOW_BLOCK_META_OVERLAY = 			new ConfigWrapper<>(false);
     public static ConfigWrapper<Boolean> BADGES_HUD = 						new ConfigWrapper<>(true);
-    public static ConfigWrapper<Boolean> HEALTHBAR_HUD = 					new ConfigWrapper<>(false);
+    public static ConfigWrapper<Boolean> HEALTHBAR_HUD = 					new ConfigWrapper<>(true);
 
     private static void initDefaults() {
         configMap.put("GEIGER_OFFSET_HORIZONTAL", GEIGER_OFFSET_HORIZONTAL);


### PR DESCRIPTION
changed the default HUD value for health (aka, the bar that renders on top of mobs) to true

thanks #1569 for making it an issue, now I can justify this commit.

(But seriously, why was this false to begin with? augh)